### PR TITLE
feat: add E2E tests to CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,8 @@ on:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
       - '.github/workflows/ci.yaml'
+      - 'e2e/**'
+      - 'scripts/**'
 
   pull_request:
     paths:
@@ -15,6 +17,8 @@ on:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
       - '.github/workflows/ci.yaml'
+      - 'e2e/**'
+      - 'scripts/**'
 
 env:
   CARGO_TERM_COLOR: always
@@ -95,3 +99,25 @@ jobs:
         uses: k1LoW/octocov-action@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  e2e:
+    name: E2E Tests
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-shared-key: setup-rust-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Make test scripts executable
+        run: chmod +x e2e/*.sh scripts/*.sh
+
+      - name: Run E2E tests
+        run: ./e2e/run_all_tests.sh


### PR DESCRIPTION
## Summary
- Add comprehensive E2E test integration to CI workflow
- Ensure robust testing of ghost CLI functionality in real environments
- Run E2E tests on Ubuntu and macOS platforms (Windows excluded as unsupported)

## Changes Made
- **New CI Job**: Added `e2e` job to `.github/workflows/ci.yaml`
- **Multi-platform Support**: Ubuntu Latest and macOS Latest
- **Test Infrastructure**: 
  - Automatic release binary building
  - Script permissions setup
  - Full E2E test suite execution
- **CI Triggers**: Include `e2e/**` and `scripts/**` paths in workflow triggers

## Test Coverage
The E2E job validates:
- ✅ Background process management (`ghost run`)
- ✅ Process listing with status checking (`ghost list`)
- ✅ Log viewing functionality (`ghost log`)
- ✅ Process stopping (`ghost stop`)
- ✅ Status querying (`ghost status`)
- ✅ Direct PID killing (`ghost kill`)

## Implementation Details
1. **Setup**: Rust toolchain with caching
2. **Build**: Release binary compilation (`cargo build --release`)
3. **Permissions**: Test script executable setup (`chmod +x`)
4. **Execution**: Full test suite (`./e2e/run_all_tests.sh`)

## Validation
- ✅ Local E2E tests: All 5 test files pass
- ✅ Workflow syntax: Validated with `act` tool
- ✅ Unit tests: All 6 tests pass
- ✅ Code quality: cargo fmt + clippy clean

This ensures the ghost CLI works correctly in production-like environments
and provides confidence in releases through comprehensive testing.