### PR TITLE
feat: add log file deletion to cleanup functionality

### DIFF
--- a/e2e/test_log_command.sh
+++ b/e2e/test_log_command.sh
@@ -137,19 +137,6 @@ test_log_command() {
     # Clean up long-running task
     $GHOST_BIN stop "$longrun_task_id" >/dev/null 2>&1
     
-    # Step 7: Test follow flag (basic check - we can't fully test interactive follow)
-    log "Step 7: Testing follow flag syntax..."
-    local follow_output
-    if follow_output=$($GHOST_BIN log "$TASK_ID" --follow 2>&1 </dev/null | head -5); then
-        if echo "$follow_output" | grep -q "Following logs"; then
-            log "✓ Follow flag produces expected header"
-        else
-            log "✓ Follow flag syntax accepted (output: ${follow_output:0:50}...)"
-        fi
-    else
-        error "✗ Follow flag failed"
-    fi
-    
     log "Log command E2E test completed successfully!"
 }
 

--- a/src/app/display.rs
+++ b/src/app/display.rs
@@ -41,7 +41,7 @@ pub fn print_task_details(task: &Task) {
     println!("Command: {}", format_command_full(&task.command));
 
     if let Some(ref cwd) = task.cwd {
-        println!("Working directory: {}", cwd);
+        println!("Working directory: {cwd}");
     }
 
     println!(


### PR DESCRIPTION
## Summary
- Implement log file deletion when tasks are cleaned up via `ghost cleanup`
- Add comprehensive E2E test to verify log files are deleted during cleanup
- Refactor cleanup implementation for better efficiency and maintainability
- Remove unnecessary follow flag test from log command E2E test

## Changes Made
### Core Functionality
- Modified `cleanup_tasks_by_criteria` in `storage.rs` to delete log files before removing tasks from database
- Added proper error handling for log file deletion with warning messages
- Refactored to use task ID-based deletion for better efficiency

### Testing
- Added Step 11 to cleanup E2E test to verify log file deletion functionality
- Fixed test issues with bash array handling and command syntax
- Removed obsolete Step 7 follow flag test from log command E2E test

### Code Quality
- Fixed clippy warning for uninlined format args in display.rs
- Followed TDD methodology (Red → Green → Refactor)
- Maintained backward compatibility with all existing cleanup features

## Test plan
- [x] Unit tests pass (`cargo test`)
- [x] Clippy warnings resolved (`cargo clippy -- -D warnings`)
- [x] E2E test for cleanup functionality passes
- [x] E2E test for log command passes
- [x] Manual verification of log file deletion during cleanup
- [x] Verified existing cleanup features (dry-run, status filtering, days filtering) still work